### PR TITLE
サプライチェーン攻撃対策の設定を .npmrc に追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+registry=https://npm.flatt.tech/
+min-release-age=7


### PR DESCRIPTION
## やったこと

- `.npmrc` に Flatt Security のプロキシレジストリ (`registry=https://npm.flatt.tech/`) を追加
- `.npmrc` に `min-release-age=7` を追加し、公開から7日未満のパッケージバージョンをインストール候補から除外するようにした

npm の `min-release-age` は、条件を満たさない場合にエラーではなく古いバージョンへフォールバックする仕様のため、pnpm で発生していた Renovate の lockfile maintenance エラー (`ERR_PNPM_NO_MATCHING_VERSION`) は発生しません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パッケージマネージャーの設定を更新しました。カスタムレジストリの設定と依存関係の管理ルールを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->