### PR TITLE
FormDataリクエスト時にContent-Typeヘッダーを自動設定させる修正

### DIFF
--- a/src/kickflow-api/custom-axios-instance.ts
+++ b/src/kickflow-api/custom-axios-instance.ts
@@ -26,7 +26,7 @@ AXIOS_INSTANCE.interceptors.request.use((config) => {
     config.headers['Authorization'] = `Bearer ${accessToken}`
   }
   if (config.data instanceof FormData) {
-    delete config.headers['Content-Type']
+    config.headers.delete('Content-Type')
   }
   return config
 })

--- a/src/kickflow-api/custom-axios-instance.ts
+++ b/src/kickflow-api/custom-axios-instance.ts
@@ -25,6 +25,9 @@ AXIOS_INSTANCE.interceptors.request.use((config) => {
     config.headers = config.headers || {}
     config.headers['Authorization'] = `Bearer ${accessToken}`
   }
+  if (config.data instanceof FormData) {
+    delete config.headers['Content-Type']
+  }
   return config
 })
 


### PR DESCRIPTION
## やったこと

- axiosのリクエストインターセプターで、リクエストボディが`FormData`の場合に`Content-Type`ヘッダーを削除する処理を追加
- これにより、axiosが`multipart/form-data`と正しいboundaryを自動設定するようになり、ファイルアップロードが正常に動作するようになった

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * マルチパートフォームデータ送信時に不要な Content-Type ヘッダーを削除する処理を修正しました。これにより、ブラウザ／ライブラリ側で正しい boundary を含む multipart/form-data ヘッダーが設定され、ファイルアップロードなどの API 互換性と信頼性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->