### PR TITLE
fix: vp staged実行時のパターン未一致エラーを抑制

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     sourcemap: true,
   },
   staged: {
-    '*': 'vp check --fix',
+    '*': 'vp check --fix --no-error-on-unmatched-pattern',
   },
   lint: {
     plugins: ['oxc', 'typescript', 'unicorn'],


### PR DESCRIPTION
## やったこと

- `vite.config.ts` の `staged` 設定で `vp check --fix` に `--no-error-on-unmatched-pattern` オプションを追加しました。
- ステージされたファイルがチェック対象パターンに一致しない場合でもエラーにならず、コミットが正常に進行するようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * `vp check` コマンドが、ステージングファイルのリント確認時に設定されたパターンにマッチするファイルがない場合でもエラーを発生させなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->