### PR TITLE
fix: publishConfig.registry を npmjs.org に設定

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "author": "kickflow, Inc.",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
## やったこと

- `package.json` の `publishConfig` に `"registry": "https://registry.npmjs.org/"` を追加。
- `.npmrc` の `registry=https://npm.flatt.tech/` がワークフローの `registry-url` 指定を上書きしてしまい、`npm publish` が `ENEEDAUTH (https://npm.flatt.tech/)` で失敗していたため。
- これによりインストール時は従来どおり `.npmrc` のプロキシを使い、publish 時のみ公式 npm レジストリに公開されるよう用途を分離。

参考: 失敗した CI 実行 https://github.com/kickflow/kickflow-mcp-server/actions/runs/25198673306/job/73884862541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * npm レジストリの公開設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->