### PR TITLE
ci: スキーマ更新ワークフローのコミット対象をスキーマ関連ファイルに限定

### DIFF
--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet; then
+          if git diff --quiet -- schema.yaml src/kickflow-api/generated; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -44,6 +44,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update kickflow API schema'
+          add-paths: |
+            schema.yaml
+            src/kickflow-api/generated/**
           title: 'chore: update kickflow API schema'
           body: |
             This PR was automatically created by the schema update workflow.


### PR DESCRIPTION
## やったこと

スキーマ更新ワークフロー（`.github/workflows/update-schema.yml`）で、意図しないファイルがPRに混入する問題を修正しました。

- 変更検知（`Check for changes`）の対象を `schema.yaml` と `src/kickflow-api/generated` に限定
- `peter-evans/create-pull-request` に `add-paths` を追加し、コミット対象を `schema.yaml` と `src/kickflow-api/generated/**` のみに限定

### 背景

#226 のスキーマ更新PRに、本来含まれないはずの `CLAUDE.md` がコミットされていました。`vp install`（Vite+インストール処理）が `CLAUDE.md` 内のVite+ブロックを自動更新し、それを `create-pull-request` が全変更として取り込んでいたためです。コミット対象をスキーマ関連ファイルに絞ることで、今後この種の混入を防ぎます。

### レビュー観点

- `add-paths` のパスが、現状の `update-schema`（`schema.yaml`取得）と `generate-api`（`src/kickflow-api/generated`再生成）の出力範囲と一致しています。生成物の出力先が変わった場合はこのパスも合わせて更新が必要です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * スキーマ更新検出プロセスを最適化しました。

---

**注:** このリリースは主にCI/CDワークフローの内部改善です。エンドユーザーへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->