### PR TITLE
fix: ルートディレクトリがcwdの場合にuploadFileがAccess deniedになる不具合を修正

### DIFF
--- a/src/kickflow-api/special-handlers.ts
+++ b/src/kickflow-api/special-handlers.ts
@@ -33,7 +33,9 @@ export const specialHandlers: Record<string, SpecialHandler> = {
 
       const allowedBaseDir = fs.realpathSync(process.cwd())
       const realPath = fs.realpathSync(resolvedPath)
-      if (!realPath.startsWith(allowedBaseDir + path.sep)) {
+      const allowedPrefix =
+        allowedBaseDir === path.sep ? path.sep : allowedBaseDir + path.sep
+      if (!realPath.startsWith(allowedPrefix)) {
         throw new Error(
           `Access denied: file path must be within ${allowedBaseDir}`,
         )

--- a/src/kickflow-api/special-handlers.ts
+++ b/src/kickflow-api/special-handlers.ts
@@ -33,8 +33,9 @@ export const specialHandlers: Record<string, SpecialHandler> = {
 
       const allowedBaseDir = fs.realpathSync(process.cwd())
       const realPath = fs.realpathSync(resolvedPath)
-      const allowedPrefix =
-        allowedBaseDir === path.sep ? path.sep : allowedBaseDir + path.sep
+      const allowedPrefix = allowedBaseDir.endsWith(path.sep)
+        ? allowedBaseDir
+        : allowedBaseDir + path.sep
       if (!realPath.startsWith(allowedPrefix)) {
         throw new Error(
           `Access denied: file path must be within ${allowedBaseDir}`,

--- a/tests/kickflow-api/special-handlers.test.ts
+++ b/tests/kickflow-api/special-handlers.test.ts
@@ -272,10 +272,11 @@ describe('special-handlers', () => {
     })
 
     it('許可ディレクトリ外のパスはアクセス拒否される', async () => {
-      const cwd = process.cwd()
+      const mockedCwd = '/workspace/project'
+      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(mockedCwd)
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.realpathSync).mockImplementation((p) =>
-        p === cwd ? cwd : '/etc/passwd',
+        p === mockedCwd ? mockedCwd : '/etc/passwd',
       )
 
       const result = await executeSpecialHandler('uploadFile', {
@@ -288,6 +289,7 @@ describe('special-handlers', () => {
           error: expect.stringContaining('Access denied'),
         }),
       )
+      cwdSpy.mockRestore()
     })
 
     it('ファイル名がパスから正しく抽出される', async () => {

--- a/tests/kickflow-api/special-handlers.test.ts
+++ b/tests/kickflow-api/special-handlers.test.ts
@@ -249,6 +249,47 @@ describe('special-handlers', () => {
       )
     })
 
+    it('cwdがルートディレクトリの場合でもアップロードできる', async () => {
+      const testFilePath = '/Users/yourname/Desktop/image.png'
+      const mockFileContent = Buffer.from('file content')
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.realpathSync).mockImplementation((p) =>
+        p === process.cwd() ? '/' : testFilePath,
+      )
+      vi.mocked(fs.readFileSync).mockReturnValue(mockFileContent)
+      mockUploadFile.mockResolvedValue({ signedId: 'abc123' })
+
+      const result = await executeSpecialHandler('uploadFile', {
+        filePath: testFilePath,
+      })
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: true,
+          data: { signedId: 'abc123' },
+        }),
+      )
+    })
+
+    it('許可ディレクトリ外のパスはアクセス拒否される', async () => {
+      const cwd = process.cwd()
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.realpathSync).mockImplementation((p) =>
+        p === cwd ? cwd : '/etc/passwd',
+      )
+
+      const result = await executeSpecialHandler('uploadFile', {
+        filePath: '/etc/passwd',
+      })
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: expect.stringContaining('Access denied'),
+        }),
+      )
+    })
+
     it('ファイル名がパスから正しく抽出される', async () => {
       const cwd = process.cwd()
       const testFilePath = `${cwd}/documents/report.pdf`


### PR DESCRIPTION
## やったこと

`uploadFile` で、カレントディレクトリ（cwd）がルートディレクトリ `/` の環境のとき、正規のファイルパスを指定しても常に `Access denied` エラーになりアップロードできない不具合を修正しました。

### 原因
パスチェックで `allowedBaseDir + path.sep` を接頭辞に使っていたため、`allowedBaseDir` が `/` のとき接頭辞が `//` となり、`/Users/...` のような正規パスが一致せず必ず拒否されていました。MCPホスト環境では cwd が `/` になることがあり、その場合にファイル添付機能が実質使用不可でした。

### 修正内容
- ベースディレクトリがルート `/` の場合は接頭辞を `/` とするよう分岐を追加
- 回帰テストを2件追加
  - cwd がルートディレクトリでもアップロードできること
  - 許可ディレクトリ外のパスは従来どおりアクセス拒否されること

### 確認したこと
- `vp check`（プロジェクト全体）: 0 errors
- `vp test`: 全72件パス
- 実環境での動作確認: cwd=`/` を再現した実行で修正前=`Access denied` / 修正後=通過することを確認。実APIへのアップロード（signedId取得）およびコメント添付までの一連の動作も確認済み

### レビュー観点
- ルート以外のディレクトリでのパス制限（ディレクトリトラバーサル対策）が従来どおり機能していること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイルアップロード時のパス検証ロジックを調整し、許可ディレクトリ判定の基準をより適切に更新しました。
  * ルート相当の許可ディレクトリなどのエッジケースでも、許可範囲外へのアップロードは確実に拒否されます。
* **テスト**
  * アップロード成功・拒否の挙動を確認するテストケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->