### PR TITLE
接続先URLとリクエストヘッダーを環境変数で設定可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ npm run dev
 
 _(開発時も `KICKFLOW_ACCESS_TOKEN` 環境変数の設定が必要です)_
 
+#### 環境変数による設定
+
+接続先や送信ヘッダーは、必要に応じて環境変数で変更できます（いずれも任意）。
+
+| 環境変数                       | 説明                                                             |
+| ------------------------------ | ---------------------------------------------------------------- |
+| `KICKFLOW_API_BASE_URL`        | 接続先のベースURL。未指定時は `https://api.kickflow.com`         |
+| `KICKFLOW_ACCESS_TOKEN_HEADER` | アクセストークンを送信するヘッダー名。未指定時は `Authorization` |
+| `KICKFLOW_API_HEADERS`         | 全リクエストに付与する追加ヘッダー（JSON形式の文字列）           |
+
+```bash
+KICKFLOW_API_HEADERS='{"X-Example-Header":"value"}' \
+KICKFLOW_ACCESS_TOKEN=your-token \
+npm run dev
+```
+
 #### テストの実行
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ function parseArguments() {
 
 環境変数:
   KICKFLOW_ACCESS_TOKEN          Kickflow アクセストークン（コマンドライン引数が優先されます）
+  KICKFLOW_API_BASE_URL          接続先のベースURL（未指定時は https://api.kickflow.com）
+  KICKFLOW_ACCESS_TOKEN_HEADER   アクセストークンを送信するヘッダー名（未指定時は Authorization）
+  KICKFLOW_API_HEADERS           全リクエストに付与する追加ヘッダー（JSON形式）
 `)
     process.exit(0)
   }

--- a/src/kickflow-api/custom-axios-instance.ts
+++ b/src/kickflow-api/custom-axios-instance.ts
@@ -1,7 +1,30 @@
 import Axios, { AxiosError, AxiosRequestConfig } from 'axios'
 
-// Kickflow APIのベースURL
-const KICKFLOW_API_BASE_URL = 'https://api.kickflow.com'
+// Kickflow APIのベースURL（環境変数で上書き可能。未指定時は本番環境）
+const KICKFLOW_API_BASE_URL =
+  process.env.KICKFLOW_API_BASE_URL ?? 'https://api.kickflow.com'
+
+// アクセストークンを送信するヘッダー名（未指定時は Authorization）
+const KICKFLOW_ACCESS_TOKEN_HEADER =
+  process.env.KICKFLOW_ACCESS_TOKEN_HEADER ?? 'Authorization'
+
+// 全リクエストに付与する追加ヘッダー（JSON形式の文字列で指定）
+function parseAdditionalHeaders(): Record<string, string> {
+  const raw = process.env.KICKFLOW_API_HEADERS
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>
+    }
+    console.warn('KICKFLOW_API_HEADERS must be a JSON object. Ignoring it.')
+  } catch {
+    console.warn('KICKFLOW_API_HEADERS is not valid JSON. Ignoring it.')
+  }
+  return {}
+}
+
+const KICKFLOW_API_HEADERS = parseAdditionalHeaders()
 
 // アクセストークンを保持する変数
 let accessToken: string | null = null
@@ -19,11 +42,13 @@ export const AXIOS_INSTANCE = Axios.create({
   },
 })
 
-// リクエストインターセプターでアクセストークンを設定
+// リクエストインターセプターで認証ヘッダーと追加ヘッダーを設定
 AXIOS_INSTANCE.interceptors.request.use((config) => {
   if (accessToken) {
-    config.headers = config.headers || {}
-    config.headers['Authorization'] = `Bearer ${accessToken}`
+    config.headers[KICKFLOW_ACCESS_TOKEN_HEADER] = `Bearer ${accessToken}`
+  }
+  for (const [key, value] of Object.entries(KICKFLOW_API_HEADERS)) {
+    config.headers[key] = value
   }
   if (config.data instanceof FormData) {
     config.headers.delete('Content-Type')

--- a/src/kickflow-api/custom-axios-instance.ts
+++ b/src/kickflow-api/custom-axios-instance.ts
@@ -42,13 +42,13 @@ export const AXIOS_INSTANCE = Axios.create({
   },
 })
 
-// リクエストインターセプターで認証ヘッダーと追加ヘッダーを設定
+// リクエストインターセプターで追加ヘッダーと認証ヘッダーを設定
 AXIOS_INSTANCE.interceptors.request.use((config) => {
-  if (accessToken) {
-    config.headers[KICKFLOW_ACCESS_TOKEN_HEADER] = `Bearer ${accessToken}`
-  }
   for (const [key, value] of Object.entries(KICKFLOW_API_HEADERS)) {
     config.headers[key] = value
+  }
+  if (accessToken) {
+    config.headers[KICKFLOW_ACCESS_TOKEN_HEADER] = `Bearer ${accessToken}`
   }
   if (config.data instanceof FormData) {
     config.headers.delete('Content-Type')

--- a/tests/kickflow-api/custom-axios-instance.config.test.ts
+++ b/tests/kickflow-api/custom-axios-instance.config.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach, vi } from 'vite-plus/test'
+import MockAdapter from 'axios-mock-adapter'
+
+async function loadModule() {
+  vi.resetModules()
+  return import('../../src/kickflow-api/custom-axios-instance.js')
+}
+
+describe('custom-axios-instance 環境変数による設定', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('未設定時はデフォルトのbaseURLとAuthorizationヘッダーを使用する', async () => {
+    const { AXIOS_INSTANCE, setKickflowAccessToken } = await loadModule()
+    const mock = new MockAdapter(AXIOS_INSTANCE)
+    setKickflowAccessToken('tok')
+    mock.onGet('/test').reply(200, {})
+
+    await AXIOS_INSTANCE.get('/test')
+
+    expect(AXIOS_INSTANCE.defaults.baseURL).toBe('https://api.kickflow.com')
+    expect(mock.history.get[0].headers?.['Authorization']).toBe('Bearer tok')
+    mock.restore()
+  })
+
+  it('KICKFLOW_API_BASE_URL で接続先を上書きできる', async () => {
+    vi.stubEnv('KICKFLOW_API_BASE_URL', 'https://example.test')
+    const { AXIOS_INSTANCE } = await loadModule()
+
+    expect(AXIOS_INSTANCE.defaults.baseURL).toBe('https://example.test')
+  })
+
+  it('KICKFLOW_ACCESS_TOKEN_HEADER でトークンのヘッダー名を変更できる', async () => {
+    vi.stubEnv('KICKFLOW_ACCESS_TOKEN_HEADER', 'X-Authorization')
+    const { AXIOS_INSTANCE, setKickflowAccessToken } = await loadModule()
+    const mock = new MockAdapter(AXIOS_INSTANCE)
+    setKickflowAccessToken('tok')
+    mock.onGet('/test').reply(200, {})
+
+    await AXIOS_INSTANCE.get('/test')
+
+    const headers = mock.history.get[0].headers
+    expect(headers?.['X-Authorization']).toBe('Bearer tok')
+    expect(headers?.['Authorization']).toBeUndefined()
+    mock.restore()
+  })
+
+  it('KICKFLOW_API_HEADERS で追加ヘッダーを付与できる', async () => {
+    vi.stubEnv('KICKFLOW_ACCESS_TOKEN_HEADER', 'X-Authorization')
+    vi.stubEnv(
+      'KICKFLOW_API_HEADERS',
+      JSON.stringify({ Authorization: 'custom' }),
+    )
+    const { AXIOS_INSTANCE, setKickflowAccessToken } = await loadModule()
+    const mock = new MockAdapter(AXIOS_INSTANCE)
+    setKickflowAccessToken('tok')
+    mock.onGet('/test').reply(200, {})
+
+    await AXIOS_INSTANCE.get('/test')
+
+    const headers = mock.history.get[0].headers
+    expect(headers?.['Authorization']).toBe('custom')
+    expect(headers?.['X-Authorization']).toBe('Bearer tok')
+    mock.restore()
+  })
+
+  it('不正なJSONのKICKFLOW_API_HEADERSは無視される', async () => {
+    vi.stubEnv('KICKFLOW_API_HEADERS', 'not-json')
+    const { AXIOS_INSTANCE, setKickflowAccessToken } = await loadModule()
+    const mock = new MockAdapter(AXIOS_INSTANCE)
+    setKickflowAccessToken('tok')
+    mock.onGet('/test').reply(200, {})
+
+    await AXIOS_INSTANCE.get('/test')
+
+    const headers = mock.history.get[0].headers
+    expect(headers?.['Authorization']).toBe('Bearer tok')
+    mock.restore()
+  })
+})

--- a/tests/kickflow-api/custom-axios-instance.config.test.ts
+++ b/tests/kickflow-api/custom-axios-instance.config.test.ts
@@ -65,6 +65,23 @@ describe('custom-axios-instance 環境変数による設定', () => {
     mock.restore()
   })
 
+  it('追加ヘッダーがアクセストークンのヘッダーを上書きしない', async () => {
+    vi.stubEnv(
+      'KICKFLOW_API_HEADERS',
+      JSON.stringify({ Authorization: 'should-not-win' }),
+    )
+    const { AXIOS_INSTANCE, setKickflowAccessToken } = await loadModule()
+    const mock = new MockAdapter(AXIOS_INSTANCE)
+    setKickflowAccessToken('tok')
+    mock.onGet('/test').reply(200, {})
+
+    await AXIOS_INSTANCE.get('/test')
+
+    const headers = mock.history.get[0].headers
+    expect(headers?.['Authorization']).toBe('Bearer tok')
+    mock.restore()
+  })
+
   it('不正なJSONのKICKFLOW_API_HEADERSは無視される', async () => {
     vi.stubEnv('KICKFLOW_API_HEADERS', 'not-json')
     const { AXIOS_INSTANCE, setKickflowAccessToken } = await loadModule()


### PR DESCRIPTION
## やったこと

接続先のベースURL・送信ヘッダーを、コードに値をハードコードせず環境変数で外部から設定できるようにしました（いずれも任意。未設定時は従来の本番挙動を維持）。

- `KICKFLOW_API_BASE_URL`: 接続先のベースURL（未指定時は `https://api.kickflow.com`）
- `KICKFLOW_ACCESS_TOKEN_HEADER`: アクセストークンを送信するヘッダー名（未指定時は `Authorization`）
- `KICKFLOW_API_HEADERS`: 全リクエストに付与する追加ヘッダー（JSON形式の文字列。不正な値は警告ログを出して無視）

あわせて `--help` と README に上記環境変数を追記し、設定挙動のテストを追加しています。

### 補足・レビュー観点

- 既存テストを含め全テストがパスすることを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 起動時に接続先APIのURL、トークン送信ヘッダー名、追加のリクエストヘッダーを環境変数で変更できるようになりました。
* **不具合修正**
  * 追加ヘッダーのJSONが不正な場合は無視され、トークン用ヘッダーは維持されます。
* **ドキュメント**
  * READMEとヘルプ表示に、環境変数の設定方法と起動例を追記しました。
* **テスト**
  * 環境変数による設定差分の動作を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->